### PR TITLE
Allow steam to load private libpangocairo

### DIFF
--- a/src/intercept/main.c
+++ b/src/intercept/main.c
@@ -87,6 +87,7 @@ static const char *steam_allowed[] = {
         "panorama",
         "libpangoft2-1.0.so",
         "libpango-1.0.so",
+        "libpangocairo-1.0.so",
 
         /* steamwebhelper */
         "libcef.so",


### PR DESCRIPTION
The latest steam beta now includes `libpangocairo-1.0.so.0` as a private
library. Currently an issue arises where it loads this file from the
distribution, but is incompatible with the privately loaded libpango due to
the lack of `pango_renderer_get_alpha` symbol.