### PR TITLE
Partially revert 2877813 | Upstream issue #82

### DIFF
--- a/src/intercept/main.c
+++ b/src/intercept/main.c
@@ -324,7 +324,7 @@ static const char *vendor_transmute_target[] = {
         "libcurl-gnutls.so.4",
         "libcurl.so.4",
 
-        "libbz2.so.1.0.6",
+        "libbz2.so.1",
 
         "libudev.so.1",
 };


### PR DESCRIPTION
As per upstream issue#82(https://github.com/solus-project/linux-steam-integration/issues/82), the specific change to explicit inclusion of libbz2.so.1.0.6, which is specific to Fedora. Is not availible on all linux flavors. In the specific case of ArchLinux, v1.0.8 is current. Symlinking from 1.0.6 > 1.0.8, does not work and is just silly. 
Given single-digit major-version numbers is used for the rest of the so-name's, and this commit breaks LSI on non-fedora OS's, treating this as a regression seems most effective.